### PR TITLE
Add explicit filter for option.

### DIFF
--- a/FsControl.Core/Foldable.fs
+++ b/FsControl.Core/Foldable.fs
@@ -88,6 +88,7 @@ module Foldable =
     type Filter() =
         inherit FilterDefault()
 
+        static member instance (_:Filter, x:'t option, _:'t option) = fun p -> match x with None -> None | Some a -> if p a then x else None
         static member instance (_:Filter, x:'t list, _:'t list) = fun p -> List.filter  p x
         static member instance (_:Filter, x:'t []  , _:'t []  ) = fun p -> Array.filter p x
         static member instance (_:Filter, x:'t IObservable, _:'t IObservable) = fun p -> Observable.filter p x

--- a/FsControl.Core/Samples/Collections.fsx
+++ b/FsControl.Core/Samples/Collections.fsx
@@ -39,6 +39,7 @@ type ZipList<'s> = ZipList of 's seq with
 let threes = filter ((=) 3) [ 1;2;3;4;5;6;1;2;3;4;5;6 ]
 let fours  = filter ((=) 4) [|1;2;3;4;5;6;1;2;3;4;5;6|]
 // let five   = filter ((=) 5) (set [1;2;3;4;5;6])             // <- Uses the default method.
+let optionFilter = filter ((=) 3) (Some 4)
 
 let arrayGroup = groupBy ((%)/> 2) [|11;2;3;9;5;6;7;8;9;10|]
 let listGroup  = groupBy ((%)/> 2) [ 11;2;3;9;5;6;7;8;9;10 ]


### PR DESCRIPTION
Default filter from foldr/monoid/pure didn't work in this case. No idea why (try removing the definition and the example in Collections.fsx won't find the appropriate instance).
