### PR TITLE
+ Lazy

### DIFF
--- a/FsControl.Core/Samples/Haskell.fsx
+++ b/FsControl.Core/Samples/Haskell.fsx
@@ -179,6 +179,7 @@ let do' = new DoNotationBuilder()
 // Test return
 let resSome2 :option<_> = return' 2
 let resSing2 :list<_>   = return' 2
+let resLazy2 :Lazy<_>   = return' 2
 
 
 // Test List Monad


### PR DESCRIPTION
Couldn't specialize `join` as it gets constrained to `Lazy<'a>`, no idea why.
